### PR TITLE
Add per-file documentation

### DIFF
--- a/ArduinoKeyBridge/README.md
+++ b/ArduinoKeyBridge/README.md
@@ -1,0 +1,31 @@
+# ArduinoKeyBridge Firmware
+
+This directory contains the main firmware for the **ArduinoKeyBridge** project. The code targets the Arduino UNO R4 WiFi and turns it into a USB keyboard host that can forward key reports over Wi‑Fi and provide visual feedback using NeoPixels.
+
+## File Overview
+
+| File | Description |
+| ---- | ----------- |
+| `ArduinoKeyBridge.ino` | Entry point that initializes logging, Wi‑Fi access point, USB host support and runs the main loop. |
+| `MinimalKeyboard.h` / `MinimalKeyboard.cpp` | Lightweight USB host keyboard parser that converts HID reports into a simple `KeyReport` structure. |
+| `MagicKeyboardKeyMap.h` | Lookup table mapping HID key codes to ASCII characters and descriptions. |
+| `TCPConnection.h` / `TCPConnection.cpp` | Manages the Wi‑Fi access point and TCP server used to send and receive `KeyReport` packets. Includes "command" and "charter" modes for remote control. |
+| `ArduinoKeyBridgeNeoPixel.h` / `ArduinoKeyBridgeNeoPixel.cpp` | Wrapper around `Adafruit_NeoPixel` for status LEDs and setup progress animations. |
+| `ArduinoKeyBridgeLogger.h` / `ArduinoKeyBridgeLogger.cpp` | Simple serial logger with different log levels and memory utilities. |
+For detailed descriptions of each file and its functions, see [docs/firmware/README.md](../docs/firmware/README.md).
+
+
+The firmware expects a USB keyboard connected via a USB host shield. It exposes a Wi‑Fi access point named `ArduinoKeyBridge` and listens for incoming connections on port `8080`.
+
+### Building and Uploading
+
+Use the `upload_monitor.sh` script in `tools/bash` to compile and upload the sketch. The script detects bootloader mode and performs a clean build automatically.
+
+```bash
+./tools/bash/upload_monitor.sh
+```
+
+### Charter Mode
+
+Charter mode lets a remote client send text which is buffered on the Arduino and typed out key by key. Toggle the mode by pressing the `F19` key or by sending the special key report defined in `TCPConnection::change_mode()`.
+

--- a/ArduinoKeyBridgeServer/README.md
+++ b/ArduinoKeyBridgeServer/README.md
@@ -1,0 +1,27 @@
+# ArduinoKeyBridge Server
+
+The Python server communicates with the Arduino firmware over TCP. It receives key reports, processes them, and can issue commands back to the device.
+
+## Main Scripts
+
+| File | Purpose |
+| ---- | ------- |
+| `main.py` | Starts the TCP client and dispatches incoming key reports to the command handler. |
+| `server.py` | Implements the `KeyBridgeTCPServer` class for managing the socket connection. |
+| `commands.py` | High level actions triggered by key sequences (e.g. screenshots). |
+| `chatgpt_client.py` | Helper for sending screenshots or text to the ChatGPT API. |
+| `database.py` | Simple SQLite/MongoDB helpers for storing data. |
+| `network_utils.py` | Utilities for discovering the Arduino IP address on the local network. |
+| `key_report.py` | Utility class representing an 8‑byte HID key report. |
+| `keymap.py` | Mapping table used by `key_report.py` to convert characters to HID codes. |
+
+Additional files such as `config.py` define project‑wide settings. The server relies on the `requirements.txt` file for Python dependencies.
+For detailed documentation of each module see [docs/server/README.md](../docs/server/README.md).
+
+
+To run the server locally:
+
+```bash
+pip install -r requirements.txt
+python main.py
+```

--- a/BluetoothKeyBridge/README.md
+++ b/BluetoothKeyBridge/README.md
@@ -1,0 +1,8 @@
+# BluetoothKeyBridge
+
+This folder contains an experimental Bluetooth Low Energy (BLE) variant of the project.
+
+- **`arduino/`** – Arduino sketch implementing a simple BLE service that echoes data between a central device and the board.
+- **`python/`** – Python client using the `bleak` library to discover the board and exchange messages.
+
+The BLE version was used for early throughput tests and is kept here for reference. The main project uses Wi‑Fi instead of BLE.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,12 @@ The project includes various development tools to streamline the development pro
 - **Accessibility Enhancements**: Develop innovative solutions for users with specialized input needs.
 
 Whether you're building a smarter workspace, experimenting with IoT, or developing custom tools, **ArduinoKeyBridge** empowers your keyboard with supercharged capabilities. Contributions and ideas are welcome to push the boundaries of what's possible!
+
+## Directory Overview
+
+- **`ArduinoKeyBridge/`** – Core firmware for the Arduino UNO R4 WiFi. See [ArduinoKeyBridge/README.md](ArduinoKeyBridge/README.md).
+- **`ArduinoKeyBridgeServer/`** – Python companion server for handling key reports and executing commands. See [ArduinoKeyBridgeServer/README.md](ArduinoKeyBridgeServer/README.md).
+- **`BluetoothKeyBridge/`** – Experimental BLE prototype with Arduino and Python examples. See [BluetoothKeyBridge/README.md](BluetoothKeyBridge/README.md).
+- **`docs/`** – Comprehensive documentation with per-file references. See [docs/README.md](docs/README.md).
+- **`tools/`** – Helper scripts for development and testing.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Documentation
+
+This folder collects additional documentation and resources for the project.
+
+- [Firmware Documentation](firmware/README.md) – Details for every file in `ArduinoKeyBridge/`.
+- [Server Documentation](server/README.md) – Details for each module in `ArduinoKeyBridgeServer/`.
+- [tools.md](tools.md) – Development helpers and upload scripts.
+- `media/` – Screenshots and other assets referenced in the docs.
+- `ArduinoBLE Library – API Documentation.pdf` – Offline copy of the ArduinoBLE API.
+- `LICENSE` – License information for bundled documentation or assets.

--- a/docs/firmware/ArduinoKeyBridge.ino.md
+++ b/docs/firmware/ArduinoKeyBridge.ino.md
@@ -1,0 +1,11 @@
+# ArduinoKeyBridge.ino
+
+Entry point for the firmware. Sets up logging, the NeoPixel status LED, Wi‑Fi access point and USB host keyboard support. Runs the main loop which processes USB events, handles incoming TCP packets and updates LED animations.
+
+## Key Functions
+
+- `setup()` – Initializes all subsystems and shows progress on the NeoPixels.
+- `loop()` – Main loop that polls USB tasks, processes TCP traffic and forwards key reports.
+- `handle_new_key_report()` – Processes a new HID report from the connected keyboard and decides whether to send it to the host computer or over the network.
+
+The sketch relies on singleton helpers defined in other modules like `TCPConnection` and `ArduinoKeyBridgeNeoPixel`.

--- a/docs/firmware/ArduinoKeyBridgeLogger.md
+++ b/docs/firmware/ArduinoKeyBridgeLogger.md
@@ -1,0 +1,15 @@
+# ArduinoKeyBridgeLogger (ArduinoKeyBridgeLogger.h / ArduinoKeyBridgeLogger.cpp)
+
+Simple serial logger used across the firmware. Supports multiple log levels and memory diagnostics.
+
+## Key Methods
+
+- `begin(baudRate)` – Initialize SerialUSB and set the start time.
+- `setLogLevel(level)` – Change the active log level.
+- `debug()/info()/warning()/error()` – Standard logging methods accepting a source tag and message.
+- `mem()` – Log memory usage and call `logMemory()`.
+- `hexDump(data, length)` – Output a hexadecimal dump for debugging.
+- `logMemory(source)` – Measure available SRAM and print usage statistics.
+- `findMaxAllocation()` – Determine the largest allocatable memory block.
+
+Convenience macros like `LOG_DEBUG` wrap these methods for easy use.

--- a/docs/firmware/ArduinoKeyBridgeNeoPixel.md
+++ b/docs/firmware/ArduinoKeyBridgeNeoPixel.md
@@ -1,0 +1,13 @@
+# ArduinoKeyBridgeNeoPixel (ArduinoKeyBridgeNeoPixel.h / ArduinoKeyBridgeNeoPixel.cpp)
+
+Wrapper around the `Adafruit_NeoPixel` library providing status indicators and animations.
+
+## Key Methods
+
+- `begin(pin, numPixels)` – Allocate the strip and set initial brightness.
+- `setColor()` / `setPixelColors()` – Set solid or per-pixel colors.
+- `setStatus*()` – Convenience helpers for idle, busy, error and success states.
+- `showSetupProgress(progress)` – Display setup progress using white pixels.
+- `rollColor(delayMs)` – Animation that rolls the current color across the strip.
+
+The singleton is accessed from other modules to signal connection status and errors.

--- a/docs/firmware/MagicKeyboardKeyMap.md
+++ b/docs/firmware/MagicKeyboardKeyMap.md
@@ -1,0 +1,7 @@
+# MagicKeyboardKeyMap.h
+
+Lookup table mapping HID key codes to ASCII characters and descriptions. Used by logging and by the server for translating between characters and key codes.
+
+## Contents
+
+Defines `KeyInfo` structures in `unifiedKeyMap` along with `unifiedKeyMapSize`. Each entry records the HID hex code, ASCII value, text description and whether the character requires the Shift modifier.

--- a/docs/firmware/MinimalKeyboard.md
+++ b/docs/firmware/MinimalKeyboard.md
@@ -1,0 +1,12 @@
+# MinimalKeyboard (MinimalKeyboard.h / MinimalKeyboard.cpp)
+
+Implements a lightweight HID keyboard parser. The class captures raw reports from the USB host shield and stores them in a `KeyReport` structure for processing.
+
+## Classes
+
+- `MinimalKeyboard` – Singleton providing `begin()`, `sendReport()`, `onNewKeyReport()` and tracking the latest report.
+- `MinimalKeyboardParser` – Derived from `KeyboardReportParser`; forwards parsed reports to `MinimalKeyboard`.
+
+## Usage
+
+`ArduinoKeyBridge.ino` registers `MinimalKeyboardParser` with the USB host library. When new key data is available, `onNewKeyReport()` creates a `KeyReport` and sets `hasNewReport` so the main loop can act on it.

--- a/docs/firmware/README.md
+++ b/docs/firmware/README.md
@@ -1,0 +1,10 @@
+# Firmware Documentation
+
+This section describes each source file in the `ArduinoKeyBridge` firmware.
+
+- [ArduinoKeyBridge.ino](ArduinoKeyBridge.ino.md)
+- [MinimalKeyboard](MinimalKeyboard.md)
+- [MagicKeyboardKeyMap](MagicKeyboardKeyMap.md)
+- [TCPConnection](TCPConnection.md)
+- [ArduinoKeyBridgeNeoPixel](ArduinoKeyBridgeNeoPixel.md)
+- [ArduinoKeyBridgeLogger](ArduinoKeyBridgeLogger.md)

--- a/docs/firmware/TCPConnection.md
+++ b/docs/firmware/TCPConnection.md
@@ -1,0 +1,14 @@
+# TCPConnection (TCPConnection.h / TCPConnection.cpp)
+
+Handles the Wi‑Fi access point and TCP networking used to communicate with the Python server. Supports command mode and charter mode for different interaction styles.
+
+## Key Methods
+
+- `startAP()` – Start the Wi‑Fi access point and listen on port 8080.
+- `poll()` – Accept a client, read incoming key reports and send them to `MinimalKeyboard`.
+- `sendKeyReport(report)` / `sendEmptyKeyReport()` – Send HID reports to the connected client.
+- `change_mode(report)` – Detect special key sequences to toggle command or charter mode.
+- `type_charter(str)` – Type a string remotely by converting characters to key reports.
+- `toggleCharterMode()` – Manually enable or disable charter mode.
+
+The class stores the client connection and manages LED feedback via `ArduinoKeyBridgeNeoPixel`.

--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -1,0 +1,15 @@
+# Server Documentation
+
+Reference for each module in the `ArduinoKeyBridgeServer` package.
+
+- [bounding_box.py](bounding_box.md)
+- [chatgpt_client.py](chatgpt_client.md)
+- [commands.py](commands.md)
+- [config.py](config.md)
+- [database.py](database.md)
+- [key_report.py](key_report.md)
+- [keymap.py](keymap.md)
+- [log.py](log.md)
+- [main.py](main.md)
+- [network_utils.py](network_utils.md)
+- [server.py](server.md)

--- a/docs/server/bounding_box.md
+++ b/docs/server/bounding_box.md
@@ -1,0 +1,12 @@
+# bounding_box.py
+
+Manages selection of a screen region using a YOLO model. Provides cropping utilities for screenshots.
+
+## Key Functions
+
+- `run_bounding_box_selection(duration)` – Capture video frames for a short period and store the best detection.
+- `process_frame(frame)` – Helper to update the bounding box from YOLO results.
+- `update(x, y)` – Grow the stored box to include the point.
+- `get_box()` / `reset()` – Access or clear the current box.
+- `capture_and_crop()` – Return a cropped frame using the saved box.
+- `validate_box(min_area)` – Ensure the box is larger than the given area.

--- a/docs/server/chatgpt_client.md
+++ b/docs/server/chatgpt_client.md
@@ -1,0 +1,10 @@
+# chatgpt_client.py
+
+Utility class for sending prompts and images to the ChatGPT API as well as converting text to speech.
+
+## Key Methods
+
+- `send_prompt(prompt)` – Submit a text prompt and return the response text.
+- `send_image_with_prompt(image_paths, prompt)` – Send one or more images with a prompt.
+- `file_to_base64(path)` – Helper used by `send_image_with_prompt()`.
+- `text_to_speech(text, voice, model, output_path)` – Use OpenAI's TTS API to save speech audio.

--- a/docs/server/commands.md
+++ b/docs/server/commands.md
@@ -1,0 +1,15 @@
+# commands.py
+
+Implements the `CommandHandler` class used by the server to react to key sequences. Provides macros for screenshots, ChatGPT integration and text-to-speech.
+
+## Key Methods
+
+- `add_report(report)` – Entry point for each received `KeyReport`.
+- `toggle_command_mode(report)` – Detect special reports for entering command mode.
+- `cmd_screenshot()` – Capture and store a screenshot from the capture card.
+- `cmd_archive_screenshot()` / `cmd_delete_screenshot()` – Manage screenshot files and database entries.
+- `cmd_toggle_bounding_box()` – Run YOLO detection to choose a crop region.
+- `cmd_set_prompt(prompt)` / `cmd_clear_prompt(type)` – Manage the prompt used for ChatGPT requests.
+- `cmd_send_to_chatgpt()` – Send active screenshots (or just the prompt) to ChatGPT and store the response.
+- `cmd_type_response()` – Type out the last ChatGPT response via the Arduino.
+- `cmd_speak()` – Convert the last ChatGPT response to speech and play it.

--- a/docs/server/config.md
+++ b/docs/server/config.md
@@ -1,0 +1,5 @@
+# config.py
+
+Holds configuration constants used by the server such as Arduino IP, API keys and data directories.
+
+Important values include `CHATGPT_API_KEY`, directory paths under `DATA_DIR` and network settings like `ARDUINO_HOST` and `ARDUINO_PORT`.

--- a/docs/server/database.md
+++ b/docs/server/database.md
@@ -1,0 +1,11 @@
+# database.py
+
+Wrapper around MongoDB used for storing screenshots and ChatGPT responses. Creates needed directories and provides helper methods for inserting and querying records.
+
+## Key Methods
+
+- `insert_screenshot(filename, path, status)` – Add a screenshot record.
+- `get_last_screenshot()` – Retrieve the most recent screenshot entry.
+- `archive_screenshot(file_id)` / `delete_screenshot(file_id)` – Move or remove screenshot files and update the database.
+- `list_active_screenshot()` / `list_archive_screenshot()` – Convenience listing helpers.
+- `reset_database()` – Wipe all collections and delete stored files (used for development).

--- a/docs/server/key_report.md
+++ b/docs/server/key_report.md
@@ -1,0 +1,11 @@
+# key_report.py
+
+Defines the `KeyReport` class which represents an HID key report and provides conversion helpers.
+
+## Key Methods
+
+- `from_tuple()` and `from_bytes()` – Create an instance from raw data.
+- `to_bytes()` – Serialize back to 8 bytes.
+- `char_to_key_report(char)` – Convert a character to a `KeyReport` using `KEY_MAP`.
+- `key_report_to_char(modifiers, keycode)` – Reverse lookup from key code to character.
+- `is_empty()` – True if no modifiers and all keys are zero.

--- a/docs/server/keymap.md
+++ b/docs/server/keymap.md
@@ -1,0 +1,5 @@
+# keymap.py
+
+Mapping table from characters to HID key codes used by the Python server. Mirrors the lookup table in the firmware.
+
+Use `KEY_MAP[char]` to obtain `(keycode, shifted)` pairs for building `KeyReport` instances.

--- a/docs/server/log.md
+++ b/docs/server/log.md
@@ -1,0 +1,3 @@
+# log.py
+
+Configures a package-wide logger with optional color output. `get_logger(name)` returns a child logger and `set_log_level(level)` adjusts verbosity.

--- a/docs/server/main.md
+++ b/docs/server/main.md
@@ -1,0 +1,9 @@
+# main.py
+
+Starts the TCP client and dispatches key reports to `CommandHandler`.
+
+## Flow
+
+1. Print a startup message and locate the Arduino IP.
+2. Create `KeyBridgeTCPServer` and `CommandHandler` instances.
+3. Enter a loop reading key reports and passing them to the handler.

--- a/docs/server/network_utils.md
+++ b/docs/server/network_utils.md
@@ -1,0 +1,7 @@
+# network_utils.py
+
+Helper functions for discovering the Arduino on the network and displaying a startup message.
+
+- `get_gateway_mac()` – Return the gateway IP and MAC address.
+- `find_arduino_ip()` – Scan the ARP table for the configured Arduino MAC.
+- `get_arduino_ip_or_exit()` – Exit the program if the Arduino cannot be found.

--- a/docs/server/server.md
+++ b/docs/server/server.md
@@ -1,0 +1,11 @@
+# server.py
+
+Defines the `KeyBridgeTCPServer` class which manages the TCP connection to the Arduino firmware.
+
+## Key Methods
+
+- `connect_and_init()` – Connect to the Arduino and send an initial empty report.
+- `send_key_report()` / `send_string()` – Send raw reports or text via charter mode.
+- `receive_key_report()` – Read 8-byte reports with timeout handling.
+- `poll()` – Non-blocking check for new reports and queue them.
+- `begin()` – Loop until a connection succeeds then start polling.


### PR DESCRIPTION
## Summary
- document every firmware file individually in `docs/firmware`
- document each Python module in `docs/server`
- link new docs from project READMEs
- update docs index and root README

## Testing
- `pytest -q` *(fails: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_683d021620d883308a0d7fa4db816769